### PR TITLE
docs: fix typo in README regarding 'release' page

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 | `ChatCommand` | 允许在游戏聊天框中执行控制台指令 | [➡️](Mods/ChatCommand/README.md)
 | `CommandWebUI` | 在web浏览器中使用smapi控制台 | [➡️](Mods/CommandWebUI/README.md)|
 
->在`realase`页中,会打包其他作者的Mod(与本项目搭配使用更佳的Mods)，可根据`manifest.json`中的信息找到对应的仓库/作者并且为他们提供支持
+>在`release`页中,会打包其他作者的Mod(与本项目搭配使用更佳的Mods)，可根据`manifest.json`中的信息找到对应的仓库/作者并且为他们提供支持
 
 
 ## 😘 社区支持


### PR DESCRIPTION
Corrected the spelling of 'release' in the README file.